### PR TITLE
fix(page): Set font-family property on body tag

### DIFF
--- a/hub/styles.css
+++ b/hub/styles.css
@@ -16,6 +16,7 @@ table, tbody, thead, tr, th, td { /* table elements */
 }
 body {
   background: #fff;
+  font-family: adobe-clean, sans-serif;
 }
 main {
   visibility: hidden;
@@ -27,7 +28,6 @@ main.fedpub--ready {
   max-width: 800px;
   margin: auto;
   padding: 20px 0;
-  font-family: adobe-clean, sans-serif;
   line-height: 1.5;
   font-size: 14px;
 }


### PR DESCRIPTION
FEDS navigation uses the font family set at body level; the proper value - `adobe-clean` - needs to be set.
Fixes #22 