### PR TITLE
Add Spectrum buttons; change FOUC strategy

### DIFF
--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -13,10 +13,12 @@
   const CONFIG = {
     SELECTORS: {
       NAMESPACE: 'fedpub',
-      WRAPPER: 'fedpub-wrapper',
       MAIN: 'main',
       READY: 'fedpub--ready',
       METADATA: 'fedpub--metadata',
+      CTA: 'fedpub-cta',
+      PRIMARY_CTA: 'fedpub-cta--primary',
+      SECONDARY_CTA: 'fedpub-cta--secondary',
     },
   };
 
@@ -275,29 +277,32 @@
       const $up = $a.parentElement;
       const $twoup = $a.parentElement.parentElement;
       if ($up.childNodes.length === 1 && $up.tagName === 'P') {
-        $a.className = 'button secondary';
+        // Setting CTA parent element to `flex` in order to be able
+        // to apply all the suggested Spectrum styling.
+        // CTA buttons should not normally occur in the normal text,
+        // they should be present in the card component, so this
+        // is just a temporary solution for demo purposes
+        $up.style.display = 'flex';
+        $a.className = `${CONFIG.SELECTORS.CTA} ${CONFIG.SELECTORS.SECONDARY_CTA}`;
       }
       if ($up.childNodes.length === 1 && $up.tagName === 'STRONG'
         && $twoup.childNodes.length === 1 && $twoup.tagName === 'P') {
-        $a.className = 'button primary';
+        $twoup.style.display = 'flex';
+        $a.className = `${CONFIG.SELECTORS.CTA} ${CONFIG.SELECTORS.PRIMARY_CTA}`;
       }
     });
   }
 
-  function markReadyAfterDecorations() {
+  // Attach a 'ready' class to the main `div` once transformations are complete
+  function markPageAsReady() {
     const mainElement = document.querySelector(`${CONFIG.SELECTORS.MAIN}`);
 
     if (mainElement instanceof HTMLElement) {
-      // Attach a class to the main 'div' in the 'main' section
       const mainDiv = mainElement.children[0];
 
-      if (mainDiv instanceof HTMLElement
-          && mainDiv.matches('div')) {
-        mainDiv.classList.add(CONFIG.SELECTORS.WRAPPER);
+      if (mainDiv instanceof HTMLElement && mainDiv.matches('div')) {
+        mainDiv.classList.add(CONFIG.SELECTORS.READY);
       }
-
-      // Mark the content as 'ready'
-      mainElement.classList.add(CONFIG.SELECTORS.READY);
     }
   }
 
@@ -336,7 +341,7 @@
     handleMetadata();
     decorateEmbeds();
     decorateButtons();
-    markReadyAfterDecorations();
+    markPageAsReady();
   }
 
   initializeFEDS();

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -13,7 +13,6 @@
   const CONFIG = {
     SELECTORS: {
       NAMESPACE: 'fedpub',
-      MAIN: 'main',
       READY: 'fedpub--ready',
       METADATA: 'fedpub--metadata',
       CTA: 'fedpub-cta',
@@ -164,7 +163,7 @@
    * to a namespaced `div` wrapper that acts like a pseudo-component
    */
   function decorateTables() {
-    const tables = document.querySelectorAll(`${CONFIG.SELECTORS.MAIN} table`);
+    const tables = document.querySelectorAll('main table');
 
     tables.forEach((table) => {
       // Remove all empty `th` elements
@@ -295,7 +294,7 @@
 
   // Attach a 'ready' class to the main `div` once transformations are complete
   function markPageAsReady() {
-    const mainElement = document.querySelector(`${CONFIG.SELECTORS.MAIN}`);
+    const mainElement = document.querySelector('main');
 
     if (mainElement instanceof HTMLElement) {
       const mainDiv = mainElement.children[0];

--- a/hub/styles.css
+++ b/hub/styles.css
@@ -19,12 +19,6 @@ body {
   font-family: adobe-clean, sans-serif;
 }
 main {
-  visibility: hidden;
-}
-main.fedpub--ready {
-  visibility: visible;
-}
-.fedpub-wrapper {
   max-width: 800px;
   margin: auto;
   padding: 20px 0;
@@ -32,180 +26,184 @@ main.fedpub--ready {
   font-size: 14px;
 }
 @media screen and (min-width: 800px) {
-  .fedpub-wrapper {
+  main {
     font-size: 17px;
   }
 }
-.fedpub-wrapper *,
-.fedpub-wrapper *:before,
-.fedpub-wrapper *:after {
+main *,
+main *:before,
+main *:after {
   box-sizing: border-box;
 }
-.fedpub-wrapper > * {
+main > div > * {
   max-width: 600px;
   margin: auto;
   padding: 0 20px;
 }
 @media screen and (min-width: 800px) {
-  .fedpub-wrapper > * {
+  main > div > * {
     padding: 0;
   }
 }
-.fedpub-wrapper h1,
-.fedpub-wrapper h2,
-.fedpub-wrapper h3,
-.fedpub-wrapper h4,
-.fedpub-wrapper h5,
-.fedpub-wrapper h6 {
+main h1,
+main h2,
+main h3,
+main h4,
+main h5,
+main h6 {
   line-height: 1.3;
   font-weight: 700;
 }
-.fedpub-wrapper h1 {
+main h1 {
   margin-top: 32px;
   margin-bottom: 9px;
   font-size: 36px;
 }
 @media screen and (min-width: 800px) {
-  .fedpub-wrapper h1 {
+  main h1 {
     margin-top: 39px;
     margin-bottom: 11px;
     font-size: 44px;
   }
 }
-.fedpub-wrapper h2 {
+main h2 {
   margin-top: 25px;
   margin-bottom: 7px;
   font-size: 28px;
 }
 @media screen and (min-width: 800px) {
-  .fedpub-wrapper h2 {
+  main h2 {
     margin-top: 30px;
     margin-bottom: 9px;
     font-size: 34px;
   }
 }
-.fedpub-wrapper h3 {
+main h3 {
   margin-top: 20px;
   margin-bottom: 6px;
   font-size: 22px;
 }
 @media screen and (min-width: 800px) {
-  .fedpub-wrapper h3 {
+  main h3 {
     margin-top: 24px;
     margin-bottom: 7px;
     font-size: 27px;
   }
 }
-.fedpub-wrapper h4 {
+main h4 {
   margin-top: 16px;
   margin-bottom: 5px;
   font-size: 18px;
 }
 @media screen and (min-width: 800px) {
-  .fedpub-wrapper h4 {
+  main h4 {
     margin-top: 20px;
     margin-bottom: 6px;
     font-size: 22px;
   }
 }
-.fedpub-wrapper h5 {
+main h5 {
   margin-top: 14px;
   margin-bottom: 4px;
   font-size: 16px;
 }
 @media screen and (min-width: 800px) {
-  .fedpub-wrapper h5 {
+  main h5 {
     margin-top: 17px;
     margin-bottom: 5px;
     font-size: 19px;
   }
 }
-.fedpub-wrapper h6 {
+main h6 {
   margin-top: 12px;
   margin-bottom: 4px;
   font-size: 14px;
 }
 @media screen and (min-width: 800px) {
-  .fedpub-wrapper h6 {
+  main h6 {
     margin-top: 15px;
     margin-bottom: 4px;
     font-size: 17px;
   }
 }
-.fedpub-wrapper h1 + p {
+main h1 + p {
   margin-top: 14px;
   margin-bottom: 4px;
   font-size: 16px;
   line-height: 1.3;
 }
 @media screen and (min-width: 800px) {
-  .fedpub-wrapper h1 + p {
+  main h1 + p {
     margin-top: 17px;
     margin-bottom: 5px;
     font-size: 19px;
   }
 }
-.fedpub-wrapper p {
+main p {
   margin-bottom: 11px;
   margin-top: 11px;
 }
 @media screen and (min-width: 800px) {
-  .fedpub-wrapper p {
+  main p {
     margin-bottom: 13px;
     margin-top: 13px;
   }
 }
-.fedpub-wrapper a {
+main a {
   text-decoration: none;
   color: #1473e6;
 }
-.fedpub-wrapper a:hover {
+main a:hover {
   text-decoration: underline;
 }
-.fedpub-wrapper strong {
+main strong {
   font-weight: 700;
 }
-.fedpub-wrapper em {
+main em {
   font-style: italic;
 }
-.fedpub-wrapper ul,
-.fedpub-wrapper ol {
+main ul,
+main ol {
   padding-left: 30px;
   margin-bottom: 30px;
 }
-.fedpub-wrapper ul {
+main ul {
   list-style-type: disc;
 }
-.fedpub-wrapper ol {
+main ol {
   list-style-type: decimal;
 }
-.fedpub-wrapper li {
+main li {
   margin-bottom: 11px;
   margin-top: 11px;
 }
-.fedpub-wrapper li:last-child {
+main li:last-child {
   margin-bottom: 0;
 }
 @media screen and (min-width: 800px) {
-  .fedpub-wrapper li {
+  main li {
     margin-bottom: 13px;
     margin-top: 13px;
   }
 }
-.fedpub-wrapper table {
+main table {
+  visibility: hidden;
   border-collapse: collapse;
+}
+main .fedpub--ready table {
+  visibility: visible;
 }
 .fedpub--callout {
   position: relative;
   max-width: 100%;
-  padding: 64px 20px;
+  padding: 40px 20px;
   margin-bottom: 20px;
   margin-top: 20px;
   background: #f5f5f5;
 }
 @media screen and (min-width: 800px) {
   .fedpub--callout {
-    padding: 64px 100px;
+    padding: 40px 100px;
   }
 }
 .fedpub--callout:before {
@@ -237,43 +235,58 @@ main.fedpub--ready {
 }
 
 /* Buttons */
-main .button {
-	border-width: 2px;
-	border-style: solid;
-	border-radius: 16px;
-	min-height: 32px;
-	height: auto;
-	min-width: 72px;
-	padding: 4px 14px;
-	padding-bottom: 4.5px;
-	padding-top: 3.5px;
-	font-size: 14px;
-	font-weight: 700;
-	transition: background .13s ease-out, border-color .13s ease-out, color .13s ease-out, box-shadow .13s ease-out;
-  line-height: 1.3;
-  -webkit-appearance: none;
+main .fedpub-cta {
+  display: flex;
+  height: 32px;
+  width: auto;
+  min-width: 72px;
+  padding: 0 14px;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 16px;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 0;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  transition: background-color 130ms ease-out, border-color 130ms ease-out, color 130ms ease-out;
+  cursor: pointer;
+  text-decoration: none;
 }
-
-main .button.primary {
-	background-color: #1473e6;
-	border-color: #1473e6;
-	color: #fff;
+main .fedpub-cta--primary {
+  background-color: #1473e6;
+  border-color: #1473e6;
+  color: #ffffff;
 }
-
-main .button.primary:hover {
-	background-color: #0d66d0;
-	border-color: #0d66d0;
-	color: #fff;
+main .fedpub-cta--primary:hover,
+main .fedpub-cta--primary:focus {
+  box-shadow: none;
+  text-decoration: none;
 }
-
-main .button.secondary {
-	background-color: transparent;
-	border-color: #505050;
-	color: #505050;
+main .fedpub-cta--primary:focus {
+  outline-offset: 0;
 }
-
-main .button.secondary:hover {
-	background-color: #505050;
-	border-color: #505050;
-	color: #fff;
+main .fedpub-cta--primary:hover,
+main .fedpub-cta--primary:focus {
+  background-color: #0d66d0;
+  border-color: #0d66d0;
+}
+main .fedpub-cta--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  border-color: #4b4b4b;
+  color: #4b4b4b;
+}
+main .fedpub-cta--secondary:hover,
+main .fedpub-cta--secondary:focus {
+  box-shadow: none;
+  text-decoration: none;
+}
+main .fedpub-cta--secondary:focus {
+  outline-offset: 0;
+}
+main .fedpub-cta--secondary:hover,
+main .fedpub-cta--secondary:focus {
+  background-color: #4b4b4b;
+  color: #ffffff;
 }


### PR DESCRIPTION
## Description

This addresses styling updates, namely:
* implements Spectrum CTA styles for primary and secondary buttons;
* updates the FOUC strategy to initially hide just tables that require conversion. As soon as the decorations occur, those items will either have been transformed to a component with its own styling rules OR, if it doesn't require any transformation, the table will be shown with the default styles.

## Related Issue

https://github.com/adobe/fedpub/issues/18

## Motivation and Context

* Studio team requires particular styling for certain elements;
* The FOUC strategy has an impact on perceived performance, since it can be tied to the first contentful paint metric.

## How Has This Been Tested?

Locally:
* ensuring the styles of the CTA buttons are correctly applied;
*  checking that tables, either transformed or not, are visible at the correct time with the correct markup and styling.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
