### PR TITLE
feat(page): retrieve locale, cloud and category based on pare URL; update HTML lang.

### DIFF
--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -302,6 +302,45 @@
   }
 
   /**
+   * Parses the page URL and retrieves the locale, cloud and category.
+   * Page details are updated based on these values.
+   */
+  function handlePageDetails() {
+    const MAP = {
+      ca: { country: 'CA', language: 'en' },
+      ca_fr: { country: 'CA', language: 'fr' },
+      en: { country: 'US', language: 'en' },
+    };
+    const [locale, cloud, category] = window.location.pathname
+      .split('/').filter(isNonEmptyString);
+    let localeDetails = MAP[locale];
+    let currentLocale = locale;
+
+    if (typeof localeDetails !== 'object') {
+      // Locale is undefined or unsupported, default to "en"
+      currentLocale = 'en';
+      localeDetails = MAP[currentLocale];
+    }
+
+    window.fedPub = {
+      language: localeDetails.language,
+      country: localeDetails.country,
+      locale: currentLocale,
+    };
+
+    if (isNonEmptyString(cloud)) {
+      window.fedPub.cloud = cloud;
+    }
+
+    if (isNonEmptyString(category)) {
+      window.fedPub.category = category;
+    }
+
+    /** Set details */
+    document.querySelector('html').setAttribute('lang', window.fedPub.language);
+  }
+
+  /**
    * Initialize FEDS library
    */
   function initializeFEDS() {
@@ -321,7 +360,7 @@
     }
 
     window.fedsConfig = {
-      locale: 'en', // TODO: add locale based on URL
+      locale: window.fedPub.locale,
       content: {
         experience: 'acom', // TODO: use fedPub experience
       },
@@ -339,6 +378,7 @@
     markReadyAfterDecorations();
   }
 
+  handlePageDetails();
   initializeFEDS();
   decoratePage();
 })();


### PR DESCRIPTION
Set page properties, including locale, cloud and category.

## Description
A new `fedPub` global object containing page details like language, country, locale, content category and cloud is created. Based on the object values additional attributes are added on the page or custom configurations are done.
- html `lang` property is set based on `language` value
- FEDS library locale is configured based on `locale` value
- TBD: FEDS library experience will be retrieved based on `content category` value

## Related Issue
https://github.com/adobe/fedpub/issues/27

## Motivation and Context
- SEO & LH; `lang` attribute is needed on the page
- A different navigation experience needs to be loaded based on locale and content category

## How Has This Been Tested?
Locally, using 2 different locales (article and index page).

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
