### PR TITLE
feat(Identity): Load IMS library and use Profile Menu

### DIFF
--- a/head.html
+++ b/head.html
@@ -3,4 +3,3 @@
 <link rel="stylesheet" href="/hlx_fonts/pnv6nym.css"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script src="/hub/scripts.js" defer></script>
-<script async src="https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/feds.js" id="feds-script"></script>

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -245,6 +245,24 @@
     });
   }
 
+  /**
+   * Loads a JS file on the page
+   * @param {String} src The path to the JS file
+   * @param {Object} params The parameters used to load the file
+   */
+  function loadJS(src, params) {
+    if (isNonEmptyString(src)) {
+      const script = document.createElement('script');
+      script.setAttribute('src', src);
+      script.setAttribute('type', 'text/javascript');
+      if (typeof params === 'object' && isNonEmptyString(params.id)) {
+        script.setAttribute('id', params.id);
+      }
+
+      document.head.appendChild(script);
+    }
+  }
+
   function decorateEmbeds() {
     document.querySelectorAll('a[href]').forEach(($a) => {
       const url = new URL($a.href);
@@ -345,6 +363,19 @@
   }
 
   /**
+   * Initializes IMS library
+   */
+  function initializeIMS() {
+    window.adobeid = {
+      client_id: 'fedpub',
+      scope: 'AdobeID,openid,gnav',
+      locale: window.fedPub.locale,
+    };
+
+    loadJS('https://static.adobelogin.com/imslib/imslib.min.js');
+  }
+
+  /**
    * Initialize FEDS library
    */
   function initializeFEDS() {
@@ -372,6 +403,10 @@
         otDomainId: getOtDomainId(),
       },
     };
+
+    loadJS('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/feds.js', {
+      id: 'feds-script',
+    });
   }
 
   async function decoratePage() {
@@ -383,6 +418,7 @@
   }
 
   handlePageDetails();
+  initializeIMS();
   initializeFEDS();
   decoratePage();
 })();


### PR DESCRIPTION
Add IMS library and enable Profile Menu

## Description
Profile Menu in FEDS library is enabled only when IMS library is loaded and configured. The PR handles loading and configuring IMS library and also deals with issues that appear when using `defer` and `async` for loading configuration and scripts.

## Related Issue
https://github.com/adobe/fedpub/issues/25

## Motivation and Context
Profile Menu is needed on all adobe.com pages

## How Has This Been Tested?
Locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
