### PR TITLE
Correct favicon path

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,6 +1,6 @@
 <!-- THIS IS THE DEFAULT FILE CONTENT -->
 <link rel="stylesheet" href="/bench/dist/app.min.css"/>
-<link id="favicon" rel="icon" type="image/svg+xml" href="/icons/adobe.svg">
+<link id="favicon" rel="icon" type="image/svg+xml" href="/hub/icons/adobe.svg">
 <link rel="stylesheet" href="/hlx_fonts/pnv6nym.css"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script defer src="/bench/dist/app.min.js"></script>


### PR DESCRIPTION
The `favicon` is located at https://fedpub--adobe.hlx.live/hub/icons/adobe.svg and not https://fedpub--adobe.hlx.live/icons/adobe.svg, causing some performance testing inconsistencies.