### PR TITLE
feat(fonts): Load fonts from Typekit

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,5 +1,5 @@
-<link rel="stylesheet" href="/hub/styles.css"/>
-<link id="favicon" rel="icon" type="image/svg+xml" href="/hub/icons/adobe.svg">
-<link rel="stylesheet" href="/hlx_fonts/pnv6nym.css"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link id="favicon" rel="icon" type="image/svg+xml" href="/hub/icons/adobe.svg">
+<link rel="stylesheet" href="/hub/styles.css"/>
+<link rel="stylesheet" href="https://use.typekit.net/pnv6nym.css"/>
 <script src="/hub/scripts.js" defer></script>


### PR DESCRIPTION
Serve custom fonts from Typekit instead of local folder. 

## Description
Small PR to load custom fonts directly from Typekit.

## Motivation and Context
Akamai redirect rule does not include *hlx_fonts* folder. Recommendation was to load fonts from Typekit directly and keep consistency with other projects.

## How Has This Been Tested?
Locally - fonts are loaded from Typekit, there's no FOUC.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
