### PR TITLE
Load assets based on environment

### DIFF
--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -96,6 +96,15 @@
   };
 
   /**
+   * Determine whether the current environment is a staging one.
+   * This can occur either when previewing a page from the Git `stage` branch
+   * or when a Fedpub page is visited from Adobe's regular staging environment
+   */
+  const isStageEnvironment = window.location.hostname.indexOf('stage--') > -1
+      || window.location.hostname.indexOf('.stage.') > -1
+      || window.location.hostname === 'localhost';
+
+  /**
    * Checks whether a given parameter is a non-empty string
    * @param {String} str The parameter requiring validation
    * @return {Boolean} Whether the provided parameter is a non-empty string
@@ -451,7 +460,7 @@
       locale: `${window.fedPub.language}_${window.fedPub.country.toUpperCase()}`,
     };
 
-    loadJS('https://static.adobelogin.com/imslib/imslib.min.js');
+    loadJS(`https://static.adobelogin.com/imslib/${!isStageEnvironment ? '' : 'stg1/'}imslib.min.js`);
   }
 
   /**
@@ -483,7 +492,7 @@
       },
     };
 
-    loadJS('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/feds.js', {
+    loadJS(`https://www.${!isStageEnvironment ? '' : 'stage.'}adobe.com/etc.clientlibs/globalnav/clientlibs/base/feds.js`, {
       id: 'feds-script',
     });
   }
@@ -496,14 +505,14 @@
       adobe: {
         launch: {
           property: 'global',
-          environment: 'production',
+          environment: !isStageEnvironment ? 'production' : 'stage',
         },
         target: true,
         audienceManager: true,
       },
     };
 
-    loadJS('https://www.adobe.com/marketingtech/main.no-promise.min.js', {
+    loadJS(`https://www.adobe.com/marketingtech/main.no-promise.${!isStageEnvironment ? '' : 'stage.'}min.js`, {
       id: 'AdobeLaunch',
     });
   }


### PR DESCRIPTION
## Description

This loads certain assets (such as the IMS, FEDS and Launch libraries) based on the current environment. This will allow us and authors to preview changes before they are published live.

## Related Issue

https://github.com/adobe/fedpub/issues/42

## Motivation and Context

To make it easier for all stakeholders to test and tweak changes before they reach the production environment.

## How Has This Been Tested?

On the local environment.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
