### PR TITLE
Add default robots meta tag

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,3 +1,4 @@
+<meta name="robots" content="follow, index">
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <link id="favicon" rel="icon" type="image/svg+xml" href="/hub/icons/adobe.svg">
 <link rel="stylesheet" href="/hub/styles.css"/>


### PR DESCRIPTION
## Description

The SEO team is requesting that a default value for the `robots` meta tag is added on all Fedpub pages. If a page requires a different value, it can be set from the Metadata section of the respective article.

## Related Issue

https://github.com/adobe/fedpub/issues/45

## Motivation and Context

The purpose of the Fedpub project revolves around SEO, thus we need to implement such SEO requests.

## How Has This Been Tested?

Locally, ensuring that the `robots` meta tag is added to the `head` section.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
