### PR TITLE
Disable Target

### DIFF
--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -546,7 +546,7 @@
           property: 'global',
           environment: !isStageEnvironment ? 'production' : 'stage',
         },
-        target: true,
+        target: false,
         audienceManager: true,
       },
     };


### PR DESCRIPTION
When loading Target, a `0.01` opacity is added to body until the functionality is loaded. Because of it, the content is not visible for some time; the issue is visible on all connection types.
Marketing Tech recommended disabling Target since it's not used on the page.
