### PR TITLE
Localnav Ondrafts

### DIFF
--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -415,7 +415,7 @@
    * Page details are updated based on these values.
    */
   function handlePageDetails() {
-    const paths = window.location.pathname.replace('/bench', '')
+    const paths = window.location.pathname.replace('/bench' | '_draft', '')
       .split('/').filter(isNonEmptyString);
     // Identify hub placement in order to split paths
     const hubPosition = paths.indexOf('hub');

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -415,7 +415,7 @@
    * Page details are updated based on these values.
    */
   function handlePageDetails() {
-    const paths = window.location.pathname.replace('/bench', '').replace('/_draft', '')
+    const paths = window.location.pathname.replace('/bench', '').replace('_draft', '')
       .split('/').filter(isNonEmptyString);
 
     // Identify hub placement in order to split paths

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -415,7 +415,7 @@
    * Page details are updated based on these values.
    */
   function handlePageDetails() {
-    const paths = window.location.pathname.replace('/bench' | '_draft', '')
+    const paths = window.location.pathname.replace('/bench' && '_draft', '')
       .split('/').filter(isNonEmptyString);
     // Identify hub placement in order to split paths
     const hubPosition = paths.indexOf('hub');

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -415,12 +415,15 @@
    * Page details are updated based on these values.
    */
   function handlePageDetails() {
-    const paths = window.location.pathname.replace('/bench', '')
-      .split('/').filter(isNonEmptyString);
+    const path = window.location.pathname;
+    let paths;
 
-    if (paths.indexOf('_draft')) {
-      const draftPosition = paths.indexOf('_draft');
-      paths.slice(0, draftPosition);
+    if (path.indexOf('_draft')) {
+      paths = path.replace('/bench' && '_draft', '')
+      .split('/').filter(isNonEmptyString);
+    } else {
+      paths = path.replace('/bench', '')
+      .split('/').filter(isNonEmptyString);
     }
 
     // Identify hub placement in order to split paths

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -415,7 +415,7 @@
    * Page details are updated based on these values.
    */
   function handlePageDetails() {
-    const paths = window.location.pathname.replace('/bench', '').replace('_draft', '')
+    const paths = window.location.pathname.replace('/bench', '').replace('/_draft', '')
       .split('/').filter(isNonEmptyString);
 
     // Identify hub placement in order to split paths

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -415,7 +415,7 @@
    * Page details are updated based on these values.
    */
   function handlePageDetails() {
-    const paths = window.location.pathname.replace(/\/(bench|\_drafts)/g, '')
+    const paths = window.location.pathname.replace('/bench', '').replace('/_draft', '')
       .split('/').filter(isNonEmptyString);
 
     // Identify hub placement in order to split paths

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -415,7 +415,7 @@
    * Page details are updated based on these values.
    */
   function handlePageDetails() {
-    const paths = window.location.pathname.replace('/bench', '').replace('/_draft', '')
+    const paths = window.location.pathname.replace(/\/(bench|\_drafts)/g, '')
       .split('/').filter(isNonEmptyString);
 
     // Identify hub placement in order to split paths

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -415,16 +415,8 @@
    * Page details are updated based on these values.
    */
   function handlePageDetails() {
-    const path = window.location.pathname;
-    let paths;
-
-    if (path.indexOf('_draft')) {
-      paths = path.replace('/bench', '').replace('_draft', '')
+    const paths = window.location.pathname.replace('/bench', '').replace('/_draft', '')
       .split('/').filter(isNonEmptyString);
-    } else {
-      paths = path.replace('/bench', '')
-      .split('/').filter(isNonEmptyString);
-    }
 
     // Identify hub placement in order to split paths
     const hubPosition = paths.indexOf('hub');

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -415,8 +415,14 @@
    * Page details are updated based on these values.
    */
   function handlePageDetails() {
-    const paths = window.location.pathname.replace('/bench' && '_draft', '')
+    const paths = window.location.pathname.replace('/bench', '')
       .split('/').filter(isNonEmptyString);
+
+    if (paths.indexOf('_draft')) {
+      const draftPosition = paths.indexOf('_draft');
+      paths.slice(0, draftPosition);
+    }
+
     // Identify hub placement in order to split paths
     const hubPosition = paths.indexOf('hub');
     const pageDetails = paths.slice(0, hubPosition);

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -419,7 +419,7 @@
     let paths;
 
     if (path.indexOf('_draft')) {
-      paths = path.replace('/bench' && '_draft', '')
+      paths = path.replace('/bench', '').replace('_draft', '')
       .split('/').filter(isNonEmptyString);
     } else {
       paths = path.replace('/bench', '')


### PR DESCRIPTION
Resolving https://jira.corp.adobe.com/browse/MWPW-82702

Description
Load the appropriate local navigation in `_draft` articles.
Context: the existing logic will fetch the locale/cloud/ category from URL, e.g. www.adobe.com/<locale>/<cloud>/<category>/hub/path/to/article.html and configure feds to load the experience `fedpub/cloud/category`. The code that sets the locale/ cloud/ category is available in https://github.com/adobe/fedpub/blob/master/hub/scripts.js#L417-L455

The request is to load the correct local navigation even when the author is working on a draft, e.g. www.adobe.com/_draft/<locale>/<cloud>/<category>/hub/path/to/article.htm

Pages to test:
Draft: https://localnav-ondrafts--fedpub--elaineskpt.hlx.page/_draft/de/documentcloud/acrobat/hub/how-to/document.html
Non Draft: https://localnav-ondrafts--fedpub--elaineskpt.hlx.page/de/documentcloud/acrobat/hub/how-to/document.html

