### PR TITLE
fix: redirect urls without ending to .html

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,7 +1,7 @@
 <script> 
     if(!/\.html$/.test(window.location.pathname)) { 
         const pathWithHtmlEnding = (window.location.pathname + '.html');
-        window.location.pathname = pathWithHtmlEnding 
+        window.location.pathname = pathWithHtmlEnding;
     } 
 </script>
 <meta name="robots" content="follow, index">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For SEO reasons we should not allow documents to be reachable both via no url ending and `.html`

## Related Issue
https://jira.corp.adobe.com/browse/MWPW-98472

## Motivation and Context
Google had some SEO/indexing problems due to documents being reachable via no ending and `.html` in the url.

A JS redirect should work as a `301` according to [google SEO docs](https://developers.google.com/search/docs/advanced/crawling/301-redirects?hl=en&visit_id=637695457858406037-1113046168&rd=1#jslocation) 


## How Has This Been Tested?
Few sample URLs local tests + branch tested
1) navigate to https://redirect-urls-with-no-ending-to-html--fedpub--adobe.hlx.page/documentcloud/sign/hub/how-to/about-title-21-cfr-part-11
2) should redirect to the same url with `.html`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Note

This PR should be reverted **before** the `hlx3` migration to not have any infinite redirect loops between no ending and `.html`
