### PR TITLE
fix: read 'fedpub.cloud' from the document metadata

### DIFF
--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -476,6 +476,11 @@
     };
     
     const cloudValueMetadata = document.head.querySelector('meta[name="cloud"]');
+
+    // Assumption, if there's a cloud attribute
+    // the URL is different and we don't need to shift the array
+    // Example 1: /sign/hub/how-to/best-way-to-invoice-customers.html (should have the 'cloud' metadata)
+    // Example 2: /it/documentcloud/sign/hub/document-types/invoice-vs-receipt.html (extract cloud from URL)
     window.fedPub.cloud = cloudValueMetadata ? cloudValueMetadata.getAttribute('content') : pageDetails.shift();
 
     const category = pageDetails[pageDetails.length - 1];

--- a/hub/scripts.js
+++ b/hub/scripts.js
@@ -469,19 +469,16 @@
       localeDetails = localeMAP[locale];
     }
 
-    const cloud = pageDetails.shift();
-    const category = pageDetails.shift();
-
     window.fedPub = {
       language: localeDetails.language,
       country: localeDetails.country,
       locale,
     };
+    
+    const cloudValueMetadata = document.head.querySelector('meta[name="cloud"]');
+    window.fedPub.cloud = cloudValueMetadata ? cloudValueMetadata.getAttribute('content') : pageDetails.shift();
 
-    if (isNonEmptyString(cloud)) {
-      window.fedPub.cloud = cloud;
-    }
-
+    const category = pageDetails[pageDetails.length - 1];
     if (isNonEmptyString(category)) {
       window.fedPub.category = category;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In cases where we have a different folder structure, we want to read `window.fedpub.cloud` from the metadata instead of the URL.

## Related Issue

https://jira.corp.adobe.com/browse/MWPW-90850
Closes https://github.com/adobe/fedpub/pull/100

## Motivation and Context
We do not have consistent folder structures, thus need some extra logic to make stuff work. Also we have some pretty old code that's not needed anymore due to changes in the [helix pipeline](https://github.com/adobe/helix-pipeline-service/blob/main/src/steps/render.js)

## How Has This Been Tested?
Tested local and on branch.
https://read-cloud-from-metadata--fedpub--adobe.hlx.page/sign/hub/how-to/best-way-to-invoice-customers.html
window.fedpub = `{language: 'en', country: 'us', locale: 'en', cloud: 'documentcloud', category: 'sign'}`

https://read-cloud-from-metadata--fedpub--adobe.hlx.page/it/documentcloud/sign/hub/document-types/invoice-vs-receipt.html
window.fedpub = `{language: 'it', country: 'it', locale: 'it', cloud: 'documentcloud', category: 'sign'}`

- [x] Tested a document starting with a category
- [x] Tested a document starting with a language
- [ ] Did NOT test starting with a category, but does not have the `cloud` metadata... not sure if that exists

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
