### PR TITLE
fix: save is broken

### DIFF
--- a/tools/translation/glaas.js
+++ b/tools/translation/glaas.js
@@ -188,8 +188,12 @@ async function getFile(task, locale) {
             'X-GLaaS-AuthToken': glaas.accessToken,
         },
     });
-    // Stream the response into the file.
-    return response.blob();
+
+    if (response.ok) {
+        // Stream the response into the file.
+        return response.blob();
+    }
+    throw new Error(`Cannot download the file from GLaaS: ${task.glaas.assetPath}`);
 }
 
 export {

--- a/tools/translation/tracker.js
+++ b/tools/translation/tracker.js
@@ -34,7 +34,15 @@ async function init() {
       if (json?.webPath) {
         // compute the "real" filename, fallback to url last segment.
         const str = json?.source?.sourceLocation || json.webPath;
-        const name = str.substring(str.lastIndexOf('/') + 1, str.lastIndexOf('.'));
+
+        // temp fix to get the real file name - waiting for API to return it
+        let name = str.substring(str.lastIndexOf('/') + 1, str.lastIndexOf('.'));
+        const index = sp.indexOf('file=');
+        if (index > -1) {
+          // extract real name from editURL
+          name = sp.substring(index+5, sp.indexOf('.xlsx', index));
+        }
+
         config = {
           url: `${location.origin}${json.webPath}`,
           path: json.webPath,

--- a/tools/translation/ui.js
+++ b/tools/translation/ui.js
@@ -167,7 +167,7 @@ async function drawTracker() {
                 });
               }
               $saveToLocalSP.addEventListener('click', () => {
-                save(task);
+                save(task, true, locale);
               });
               $td.appendChild($saveToLocalSP);
               if ($view) {
@@ -290,18 +290,22 @@ async function save(task, doRefresh=true, locale) {
     if (!confirm) return;
   }
   loadingON(`Downloading ${dest} file from GLaaS`);
-  const file = await getFileFromGLaaS(task, locale);
+  try {
+    const file = await getFileFromGLaaS(task, locale);
 
-  loadingON(`Saving ${dest} file to Sharepoint`);
-  await saveFile(file, dest);
+    loadingON(`Saving ${dest} file to Sharepoint`);
+    await saveFile(file, dest);
 
-  loadingON(`File ${dest} is now in Sharepoint`);
+    loadingON(`File ${dest} is now in Sharepoint`);
 
-  if (doRefresh) {
-    loadingOFF();
-    await refresh();
+    if (doRefresh) {
+      loadingOFF();
+      await refresh();
+    }
+  } catch (err) {
+    setError('Could not save the file.', err);
+    return;
   }
-  // window.open(`${u.origin}${dest.slice(0, -5)}`);
 }
 
 async function saveAll(locale) {


### PR DESCRIPTION
File saving was broken for various reasons, main one was the name mapping: the real file name was used to create the handoffs on the GLaaS side. But the admin API has changed and the file name is filtered for URLs. No matching anymore.
Extracting the file name from the editURL until https://github.com/adobe/helix-admin/issues/281 is provided.