### PR TITLE
fix: use custom outer CDN hostname for live

### DIFF
--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -14,6 +14,7 @@
 window.hlx.initSidekick({
   project: 'FedPub',
   host: 'www.adobe.com',
+  outerHost: 'fedpub--adobe.hlx.live',
   byocdn: true,
   pushDownSelector: '#feds-header',
   hlx3: true,


### PR DESCRIPTION
Authors currently end up on the generic outer CDN `main--fedpub--adobe.hlx.live` when clicking the "Live" button - which works, but does not reflect what is delivered in production.

https://custom-outer-cdn--fedpub--adobe.hlx3.page/creativecloud/photography/hub/guides/best-lens-for-headshot-photography