### PR TITLE
fix: alternate paths should start with a slash

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -9,12 +9,12 @@ sitemaps:
         source: /hub/query-index-au.json
         destination: /hub/sitemap/sitemap-au.xml
         hreflang: en
-        alternate: au/{path}
+        alternate: /au/{path}
       de:
         source: /hub/query-index-de.json
         destination: /hub/sitemap/sitemap-de.xml
         hreflang: de
-        alternate: de/{path}
+        alternate: /de/{path}
       en:
         source: /hub/query-index-en.json
         destination: /hub/sitemap/sitemap-en.xml
@@ -24,29 +24,29 @@ sitemaps:
         source: /hub/query-index-es.json
         destination: /hub/sitemap/sitemap-es.xml
         hreflang: es
-        alternate: es/{path}
+        alternate: /es/{path}
       fr:
         source: /hub/query-index-fr.json
         destination: /hub/sitemap/sitemap-fr.xml
         hreflang: fr
-        alternate: fr/{path}
+        alternate: /fr/{path}
       it:
         source: /hub/query-index-it.json
         destination: /hub/sitemap/sitemap-it.xml
         hreflang: it
-        alternate: it/{path}
+        alternate: /it/{path}
       jp:
         source: /hub/query-index-jp.json
         destination: /hub/sitemap/sitemap-jp.xml
         hreflang: jp
-        alternate: jp/{path}
+        alternate: /jp/{path}
       kr:
         source: /hub/query-index-kr.json
         destination: /hub/sitemap/sitemap-kr.xml
         hreflang: ko
-        alternate: kr/{path}
+        alternate: /kr/{path}
       ru:
         source: /hub/query-index-ru.json
         destination: /hub/sitemap/sitemap-ru.xml
         hreflang: ru
-        alternate: ru/{path}
+        alternate: /ru/{path}


### PR DESCRIPTION
or the lookup of alternate paths will not work