### PR TITLE
feat: try extensionless in case of .html and 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,11 @@
 <head>
     <title>adobe.com: Page not found</title>
     <script type="text/javascript">
+        if (window.location.pathname.endsWith('.html')) {
+          // redirect from .html to extensionless URL
+          window.location.replace(window.location.pathname.split('.html')[0]);
+        }
+
         window.isErrorPage = true;
         window.errorCode = '404';
     </script>


### PR DESCRIPTION
A URL with `.html` extension landing on the 404 page should be redirected to its extensionless version before serving a 404.